### PR TITLE
"Overview" drawer formatting with dummy text

### DIFF
--- a/client/src/components/Overview.jsx
+++ b/client/src/components/Overview.jsx
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import Card from "react-bootstrap/Card";
 import Collapse from "react-bootstrap/Collapse";
 import DrawerHeader from "./DrawerHeader.jsx";
+import OverviewBody from "./OverviewBody.jsx";
+
+import '../styles/Overview.css';
 
 export default class Overview extends React.Component {
   constructor(props) {
@@ -28,7 +31,9 @@ export default class Overview extends React.Component {
           <DrawerHeader isOpen={this.state.open} label="Overview" />
         </Card.Header>
         <Collapse in={this.state.open}>
-          <Card.Body>This is where the product overview will go.</Card.Body>
+          <Card.Body>
+            <OverviewBody />
+          </Card.Body>
         </Collapse>
       </Card>
     );

--- a/client/src/components/OverviewBody.jsx
+++ b/client/src/components/OverviewBody.jsx
@@ -15,7 +15,7 @@ export default class OverviewBody extends React.Component {
   render() {
     return (
       <div className="drawer-content">
-        <div className="drawer-content-container product-description-container">
+        <div className="overview-content-container product-description-container">
           <h3 className="description-heading">Description</h3>
           <div className="description-copy">
             In quilt yearlings, gobblers pumpkin are porky pig beef, sheep rose
@@ -27,7 +27,7 @@ export default class OverviewBody extends React.Component {
           <div className="spacer-row-3"></div>
           <div className="spacer-row-9 r-border-bottom r-padding-bottom r-margin-bottom"></div>
         </div>
-        <div className="drawer-content-container product-features-container">
+        <div className="overview-content-container product-features-container">
           <h3 className="features-heading">Features</h3>
           <div className="features-body-container">
             <div className="features-list">
@@ -67,7 +67,7 @@ export default class OverviewBody extends React.Component {
           <div className="spacer-row-3"></div>
           <div className="spacer-row-9 r-border-bottom r-padding-bottom r-margin-bottom"></div>
         </div>
-        <div className="drawer-content-container product-included-container">
+        <div className="overview-content-container product-included-container">
           <h3 className="whats-included-heading">What's Included</h3>
           <div className="whats-included-body-container">
             <ul className="whats-included-list">

--- a/client/src/components/OverviewBody.jsx
+++ b/client/src/components/OverviewBody.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Card from "react-bootstrap/Card";
+import "../styles/OverviewBody.css";
+
+export default class OverviewBody extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      productId: 1
+    };
+  }
+
+  render() {
+    return (
+      <div className="drawer-content">
+        <div className="drawer-content-container product-description-container">
+          <h3 className="description-heading">Description</h3>
+          <div className="description-copy">
+            In quilt yearlings, gobblers pumpkin are porky pig beef, sheep rose
+            garden sage, in pitch fork sunflower cowpies mice. Ewes mushrooms
+            zucchini in forage Harvester at sheep with tractor.
+          </div>
+        </div>
+        <div className="spacer-row">
+          <div className="spacer-row-3"></div>
+          <div className="spacer-row-9 r-border-bottom r-padding-bottom r-margin-bottom"></div>
+        </div>
+        <div className="drawer-content-container product-features-container">
+          <h3 className="features-heading">Features</h3>
+          <div className="features-body-container">
+            <div className="features-list">
+              <div className="features-list-row">
+                <h4 className="feature-title body-copy">Rose garden cucumbers mice sunflower wheat in pig.</h4>
+                <p className="feature-copy">
+                  Forage Harvester rakes peacocks, squeal garden woof.
+                </p>
+              </div>
+              <div className="features-list-row">
+                <h4 className="feature-title body-copy">Goose hammers cattle rats in crows.</h4>
+                <p className="feature-copy">
+                  In quilt yearlings, gobblers pumpkin are porky pig beef, sheep
+                  rose garden sage, in pitch fork sunflower cowpies mice. Pick
+                  up truck livestock, pets and storage shed, troughs feed bal.
+                </p>
+              </div>
+              <div className="features-list-row">
+                <h4 className="feature-title body-copy">Veterinarian at Seeder eggs with watermelon ostriches.</h4>
+                <p className="feature-copy">
+                  Chainsaw foal hay hook, herbs at combine harvester, children
+                  is mallet.
+                </p>
+              </div>
+              <div className="features-list-row">
+                <h4 className="feature-title body-copy">Lamb pig rooster sheep.</h4>
+                <p className="feature-copy">
+                  Swather, cat weathervane grain trucks, hoot pony robins
+                  peacocks and kale. Mooo cat daisys, grunt in turkey coo,
+                  windmill at bull. Fertilize.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="spacer-row">
+          <div className="spacer-row-3"></div>
+          <div className="spacer-row-9 r-border-bottom r-padding-bottom r-margin-bottom"></div>
+        </div>
+        <div className="drawer-content-container product-included-container">
+          <h3 className="whats-included-heading">What's Included</h3>
+          <div className="whats-included-body-container">
+            <ul className="whats-included-list">
+              <li className="whats-included-list-item body-copy bold">
+                Lamb in eggplant baler rain barrels manure hay rake.
+              </li>
+              <li className="whats-included-list-item body-copy bold">
+                Lamb pig rooster sheep.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+OverviewBody.propTypes = {
+    productId: PropTypes.number
+}

--- a/client/src/styles/App.css
+++ b/client/src/styles/App.css
@@ -24,3 +24,7 @@ div.container {
     }
 }
 
+ul {
+    padding: 0;
+}
+

--- a/client/src/styles/Drawers.css
+++ b/client/src/styles/Drawers.css
@@ -9,6 +9,19 @@ body {
     font-family: Human BBY Web,Arial,Helvetica,sans-serif;
 }
 
+h4 {
+    font-weight: bold;
+}
+
+ul {
+    padding: 0;
+}
+
+.body-copy {
+    font-size: 13px;
+    line-height: normal;
+}
+
 .drawers {
     width: 100%;
     border-bottom-color: rgb(197, 203, 213);
@@ -38,4 +51,35 @@ body {
 
 .drawer-caret {
     flex: 0 0 25px;
+}
+
+.spacer-row {
+    display: flex;
+}
+
+.spacer-row-3, .spacer-row-9 {
+    position: relative;
+    min-height: 1px;
+    margin-left: -10px;
+    /* margin-right: -10px; */
+}
+
+.spacer-row-9 {
+    flex: 3;
+}
+
+.spacer-row-3 {
+    flex: 1;
+}
+
+.r-padding-bottom {
+    padding-bottom: 24px;
+}
+
+.r-margin-bottom {
+    margin-bottom: 24px;
+}
+
+.r-border-bottom {
+    border-bottom: 1px solid #c5cbd5;
 }

--- a/client/src/styles/Overview.css
+++ b/client/src/styles/Overview.css
@@ -1,0 +1,7 @@
+* {
+    box-sizing: border-box;
+}
+
+h3 {
+    font-size: 20px;
+}

--- a/client/src/styles/OverviewBody.css
+++ b/client/src/styles/OverviewBody.css
@@ -2,15 +2,15 @@
     box-sizing: border-box;
 }
 
-.drawer-content-container {
+.overview-content-container {
     display: flex;
 }
 
-.drawer-content-container:first-child {
+.overview-content-container:first-child {
     margin-top: 24px;
 }
 
-.drawer-content-container:last-child {
+.overview-content-container:last-child {
     margin-bottom: 24px;
 }
 

--- a/client/src/styles/OverviewBody.css
+++ b/client/src/styles/OverviewBody.css
@@ -1,0 +1,46 @@
+* {
+    box-sizing: border-box;
+}
+
+.drawer-content-container {
+    display: flex;
+}
+
+.drawer-content-container:first-child {
+    margin-top: 24px;
+}
+
+.drawer-content-container:last-child {
+    margin-bottom: 24px;
+}
+
+.description-heading, .features-heading, .whats-included-heading {
+    width: 25%;
+    align-items: flex-start;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.description-copy, .features-body-container, .whats-included-body-container {
+    width: 75%;
+}
+
+.whats-included-list-item {
+    list-style: none;
+    padding-bottom: 10px;
+}
+
+h4 {
+    padding-top: 11px;
+    padding-bottom: 6px;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+p {
+    margin-bottom: 9px;
+}
+
+li.bold {
+    font-weight: bold;
+}


### PR DESCRIPTION
This pull request encompasses the creation of formatted dummy content in the Overview drop-down drawer (no database connection or dynamic data rendering).

- Added OverviewBody component to render formatted Overview categories and info to the page
- PLEASE DO NOT DELETE BRANCH AFTER APPROVAL/MERGE - I will be returning to this branch to add database functionality and dynamic rendering with more subcomponents.